### PR TITLE
Fix default negative offset in file_get_contents

### DIFF
--- a/SimpleHTMLDom.php
+++ b/SimpleHTMLDom.php
@@ -81,7 +81,7 @@ class SimpleHTMLDom extends \yii\helpers\Inflector
 {
     // get html dom from file
     // $maxlen is defined in the code as PHP_STREAM_COPY_ALL which is defined as -1.
-    public static function file_get_html( $url, $use_include_path = false, $context = null, $offset = -1, $maxLen = -1, $lowercase = true, $forceTagsClosed = true, $target_charset = DEFAULT_TARGET_CHARSET, $stripRN = true, $defaultBRText = DEFAULT_BR_TEXT, $defaultSpanText = DEFAULT_SPAN_TEXT )
+    public static function file_get_html( $url, $use_include_path = false, $context = null, $offset = 0, $maxLen = -1, $lowercase = true, $forceTagsClosed = true, $target_charset = DEFAULT_TARGET_CHARSET, $stripRN = true, $defaultBRText = DEFAULT_BR_TEXT, $defaultSpanText = DEFAULT_SPAN_TEXT )
     {
         // We DO force the tags to be terminated.
         $dom      = new simple_html_dom( null, $lowercase, $forceTagsClosed, $target_charset, $stripRN, $defaultBRText, $defaultSpanText );


### PR DESCRIPTION
After PHP 7.1 the function file_get_contents has a different meaning
of the offset parameter. Check the changelog from

http://php.net/manual/en/function.file-get-contents.php

Negative number now means seeking from end of file.

This change should be retro-compatible.